### PR TITLE
Implement pasting of tables

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -199,4 +199,37 @@ export default class TableBlock {
   destroy() {
     this.table.destroy();
   }
+
+  /**
+   * Table onPaste configuration
+   *
+   * @public
+   */
+  static get pasteConfig() {
+    return { tags: ['TABLE', 'TR', 'TH', 'TD'] };
+  }
+
+  /**
+   * On paste callback that is fired from Editor
+   *
+   * @param {PasteEvent} event - event with pasted data
+   */
+  onPaste(event) {
+    const table = event.detail.data;
+    // This isn't ideal. Ideally the plugin would allow individual cells to be
+    // headings rather than the first row.
+    const firstRowHeading =
+      table.querySelector(':scope > thead, tr:first-of-type th');
+    const content = Array.from(table.querySelectorAll('tr')).map((row) => (
+      Array.from(row.querySelectorAll('th, td')).map((cell) => cell.innerText)
+    ));
+
+    this.data = {
+      withHeadings: firstRowHeading !== null,
+      content
+    };
+    if (this.table.wrapper) {
+      this.table.wrapper.replaceWith(this.render());
+    }
+  }
 }


### PR DESCRIPTION
Implement onPaste handler to insert pasted tables. Relies on https://github.com/codex-team/editor.js/pull/1807

Small note, I think the choice to only have a heading row at the top is suboptimal. Once this code is merged I am willing to take a stab at implementing per-cell heading tuning. th's are valid anywhere in a table not just the first row. It would actually make logic for pasting a lot simpler too. Should potentially allow colspan'ing also.