### PR TITLE
fix: row deletion error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@editorjs/table",
   "description": "Table for Editor.js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "main": "./dist/table.js",
   "scripts": {

--- a/src/table.js
+++ b/src/table.js
@@ -721,7 +721,7 @@ export default class Table {
     }
 
     if (!this.isRowMenuShowing) {
-      if (row > 0 && column <= this.numberOfColumns) { // not sure this statement is needed. Maybe it should be fixed in getHoveredCell()
+      if (row > 0 && row <= this.numberOfRows) { // not sure this statement is needed. Maybe it should be fixed in getHoveredCell()
         this.toolboxRow.show(() => {
           const hoveredRowElement = this.getRow(row);
           const { fromTopBorder } = $.getRelativeCoordsOfTwoElems(this.table, hoveredRowElement);


### PR DESCRIPTION
Closes: #79

This error is caused by some simple typing errors in `updateToolboxesPosition` function