### PR TITLE
fix(ci): update node version from 12 to 16

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: yarn
       - run: yarn build


### PR DESCRIPTION
Fix for another CI [problem](https://github.com/editor-js/table/actions/runs/3591690939/jobs/6046523925#step:4:14):

```
error eslint-plugin-jsdoc@39.6.4: The engine "node" is incompatible with this module. Expected version "^14 || ^16 || ^17 || ^18 || ^19". Got "12.22.12"
```