### PR TITLE
Improve the cells counter based on selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@editorjs/table",
   "description": "Table for Editor.js",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "main": "./dist/table.js",
   "scripts": {

--- a/src/table.js
+++ b/src/table.js
@@ -279,7 +279,7 @@ export default class Table {
    * @returns {HTMLElement}
    */
   getCell(row, column) {
-    return this.table.querySelector(`.${CSS.row}:nth-child(${row}) .${CSS.cell}:nth-child(${column})`);
+    return this.table.querySelectorAll(`.${CSS.row}:nth-child(${row}) .${CSS.cell}`)[column - 1];
   }
 
   /**
@@ -570,7 +570,7 @@ export default class Table {
    */
   get numberOfColumns() {
     if (this.numberOfRows) {
-      return this.table.querySelector(`.${CSS.row}:first-child`).childElementCount;
+      return this.table.querySelectorAll(`.${CSS.row}:first-child .${CSS.cell}`).length;
     }
 
     return 0;


### PR DESCRIPTION
Resolves #85 

So, (Node.)childElementCount may differ from the actual state of the table due to some browser add-ons that add their own block to the contenteditable.
In order to fix this, we need to associate the functions of getting cells only with cells.
Previously, nth-child selectors were used. But they react to all the elements inside the rows. We only need cells, respectively, the simplest option is to replace nth-child with a selector for all cells and select a new one from the array.
Also, to count the number of columns we'll count the size of the array of cells and not the elements inside