### PR TITLE
Add Documentation for I18n Support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,41 @@ var editor = EditorJS({
 | `cols`             | `number` | initial number of columns. `2` by default |
 | `withHeadings`             | `boolean` | toggle table headings. `false` by default |
 
+## I18n support
+
+This tool supports the [i18n api](https://editorjs.io/i18n-api).
+To localize UI labels, put this object to your i18n dictionary under the `tools` section:
+
+```json
+{
+    "messages": {
+        "blockTunes": {
+            
+        },
+        "ui": {
+            
+        },
+        "toolNames": {
+            
+        },
+        "tools": {
+            "table": {
+                "With headings": "עם כותרת",
+                "Without headings": "ללא כותרת",
+                "Add row above": "הוספת שורה למעלה",
+                "Add row below": "הוספת שורה למטה",
+                "Delete row": "מחיקת שורה",
+                "Delete column": "מחיקת עמודה",
+                "Add column to left": "הוספת עמודה משמאל",
+                "Add column to right": "הוספת עמודה מימין"
+            }
+        }
+    }
+}
+```
+
+See more instructions about Editor.js internationalization here: [https://editorjs.io/internationalization](https://editorjs.io/internationalization)
+
 ## Output data
 
 This Tool returns `data` in the following format


### PR DESCRIPTION
### PR: Update README for I18n Support in Table Tool for Editor.js

#### Summary
This PR aims to enhance the README of the Table Tool for Editor.js by providing comprehensive information about the newly added support for the I18n API. The updated README includes a detailed example demonstrating how to localize UI labels using the i18n dictionary under the tools section. Additionally, it incorporates a reference to more in-depth instructions on internationalization in Editor.js.

#### Key Additions
- Explanation of how the Table Tool supports the I18n API.
- Code snippet illustrating the utilization of the i18n dictionary for localizing UI labels.
- Link to further documentation on internationalization in Editor.js.

These additions will greatly benefit users who are unfamiliar with the tool, helping them understand its I18n capabilities and providing guidance on effectively leveraging them.

#### Related Issue
Linked issue: [i18n Configuration for the tool #127](https://github.com/editor-js/table/issues/127)

#### Type of Change
Documentation Update

#### Checklist
- [x] Documentation has been updated accordingly.
- [x] The related issue has been properly linked.
- [x] This PR is ready for review.

#### Testing
A visual review of the updated README content was conducted to ensure correct markdown syntax and accurate content descriptions.
