### PR TITLE
fix(onchange): onchange won't be fired on table hovering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@editorjs/table",
   "description": "Table for Editor.js",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "main": "./dist/table.js",
   "scripts": {

--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -61,6 +61,8 @@ export default class Toolbox {
       Toolbox.CSS.toolbox,
       (this.cssModifier ? `${Toolbox.CSS.toolbox}--${this.cssModifier}` : '')
     ]);
+
+    wrapper.dataset.mutationFree = 'true';
     const popover = this.createPopover();
     const toggler = this.createToggler();
 


### PR DESCRIPTION
This PR fixes unnecessary `onChange` firings on table hovering.

The problem was caused by `.tc-toolbox` attribute change, so I've added a `data-mutation-free` label on it.

![image](https://github.com/editor-js/table/assets/3684889/afb3b0dc-23be-436d-bf95-030f6038b27e)


Resolves #125 