### PR TITLE
feat: Enable useStrictCSP for cssInjectedByJsPlugin

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -19,5 +19,5 @@ export default {
     VERSION: JSON.stringify(VERSION),
   },
 
-  plugins: [cssInjectedByJsPlugin()],
+  plugins: [cssInjectedByJsPlugin({useStrictCSP: true})],
 };


### PR DESCRIPTION
Enables useStrictCSP when injecting styles. See https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean
