### PR TITLE
Do not sanitize <br> while inline toolbar enabled

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -45,6 +45,19 @@ export default class TableBlock {
   }
 
   /**
+   * Do not sanitize <br> while inline toolbar enabled
+   *
+   * @returns {object}
+   * @public
+   */
+  static get sanitize() {
+    return {
+      br: {
+      }
+    }
+  }
+
+  /**
    * Render plugin`s main Element and fill it with saved data
    *
    * @param {TableData} data — previously saved data


### PR DESCRIPTION
If we enabled the inlineToolbar in table plugin, the <br> tags were removed from the outcome HTML.
(It works fine while inlineToolbar is disabled)