### PR TITLE
chore: bump version to 2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@editorjs/table",
   "description": "Table for Editor.js",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "license": "MIT",
   "repository": "https://github.com/editor-js/table",
   "files": [


### PR DESCRIPTION
Due to a failing workflow, the fix in #162 didn't get published to NPM.