### PR TITLE
Add cell options

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
           inlineToolbar: true,
           config: {
             withHeadings: true,
+            presetColors: ["#ccaaaa", "#ffffff", "#6699cc"],
             maxRows: 5,
             maxCols: 5
           }
@@ -65,9 +66,9 @@
             data: {
               withHeadings: true,
               content: [
-                ["English", "Russian", "Japanese"], 
-                ["Sweet", "Сладкий", "あまい"], 
-                ["Good morning", "Доброе утро", "おはようございます"]]
+                [{ content: "English", backgroundColor: "#ccaaaa", width: 1.5 }, "Russian", "Japanese"],
+                [{ content: "Sweet", width: 1.5 }, "Сладкий", "あまい"],
+                [{ content: "Good morning", width: 1.5 }, "Доброе утро", "おはようございます"]]
             }
           }
         ],

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -17,6 +17,7 @@ import { IconTable, IconTableWithHeadings, IconTableWithoutHeadings, IconStretch
 /**
  * @typedef {object} TableConfig - object with the data transferred to form a table
  * @property {boolean} withHeading - setting to use cells of the first row as headings
+ * @property {string[]} presetColors - array of preset colors
  * @property {string[][]} content - two-dimensional array which contains table content
  */
 /**

--- a/src/table.js
+++ b/src/table.js
@@ -289,8 +289,8 @@ export default class Table {
 
   setCellWidth({row, column, adjustedWidth = 0, defaultWidth = 1}) {
     const cell = this.getCell(row, column);
-    const width = parseFloat(cell.dataset.width) + adjustedWidth || defaultWidth;
-    cell.dataset.width = Math.max(width, 0.1);
+    const width = parseFloat(cell.dataset.width) || defaultWidth;
+    cell.dataset.width = Math.max(width + adjustedWidth, 0.1);
   }
 
   /**
@@ -555,6 +555,7 @@ export default class Table {
       addColButton.classList.add(CSS.addColumnDisabled);
     }
     this.addHeadingAttrToFirstRow();
+    this.adjustColumnWidths();
   };
 
   /**
@@ -567,6 +568,7 @@ export default class Table {
   addRow(index = -1, setFocus = false) {
     let insertedRow;
     let rowElem = $.make('div', CSS.row);
+    const rowBlueprint = this.getRow(1); // Use this row as the blueprint to copy the width of the columns
 
     if (this.tunes.withHeadings) {
       this.removeHeadingAttrFromFirstRow();
@@ -595,6 +597,7 @@ export default class Table {
     }
 
     this.fillRow(insertedRow, numberOfColumns);
+    this.copyColumnWidthsFromBlueprint(rowBlueprint, insertedRow);
 
     if (this.tunes.withHeadings) {
       this.addHeadingAttrToFirstRow();
@@ -610,8 +613,32 @@ export default class Table {
     if (this.config && this.config.maxrows && this.numberOfRows >= this.config.maxrows && addRowButton) {
       addRowButton.classList.add(CSS.addRowDisabled);
     }
+
+    this.adjustColumnWidths();
     return insertedRow;
   };
+
+  /**
+   * Copy the width of the columns from the blueprint row to the target row
+   *
+   * @param {HTMLElement} blueprintRow - the row to copy the width from
+   * @param {HTMLElement} targetRow - the row to copy the width to
+   */
+  copyColumnWidthsFromBlueprint(blueprintRow, targetRow) {
+    console.log('copyColumnWidthsFromBlueprint', blueprintRow, targetRow);
+    if (!blueprintRow || !targetRow) {
+      return;
+    }
+
+    const blueprintCells = blueprintRow.querySelectorAll(`.${CSS.cell}`);
+    const targetCells = targetRow.querySelectorAll(`.${CSS.cell}`);
+
+    blueprintCells.forEach((cell, index) => {
+      if (cell.dataset.width) {
+        targetCells[index].dataset.width = cell.dataset.width;
+      }
+    });
+  }
 
   /**
    * Delete a column by index

--- a/src/table.js
+++ b/src/table.js
@@ -972,7 +972,7 @@ export default class Table {
   }
 
   /**
-   * Update toolboxes position
+   * Update toolboxes position, this is used to display the controls at column/row/cell level
    *
    * @param {number} row - hovered row
    * @param {number} column - hovered column
@@ -980,9 +980,13 @@ export default class Table {
   updateToolboxesPosition(row = this.hoveredRow, column = this.hoveredColumn) {
     if (!this.isColumnMenuShowing) {
       if (column > 0 && column <= this.numberOfColumns) { // not sure this statement is needed. Maybe it should be fixed in getHoveredCell()
+        const hoveredColumnElement = this.getCell(1, column)
+        const { fromLeftBorder } = $.getRelativeCoordsOfTwoElems(this.table, hoveredColumnElement);
+        const { width } = hoveredColumnElement.getBoundingClientRect();
+
         this.toolboxColumn.show(() => {
           return {
-            left: `calc((100% - var(--cell-size)) / (${this.numberOfColumns} * 2) * (1 + (${column} - 1) * 2))`
+            left: `${fromLeftBorder + width / 2}px`
           };
         });
       }


### PR DESCRIPTION
- Add ability to change colour for cell background ( can be passed through a config )
- Add ability to increase and decrease column width

Add functionality that enables cell toolbox.  This enables us to add actions on a cell level rather than a row or column.  This gives us the ability to change a cell background or other features in the future.

Add ability to pass width with the data for table, these will get set to the dataset attribute, since editorjs uses css grids for tables have to manipulate the grid columns so that it can adjust it self properly.  When increase or decrease is selected then it adjusts the fr for all the columns.  This is then taken into consideration when a new row is added.


https://github.com/user-attachments/assets/d62a7473-cd5c-424c-9702-a47ab8bd7ece

