### PR TITLE
fixed cursor jumps issue when removing some text

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -691,11 +691,7 @@ export default class Table {
    * @param {KeyboardEvent} event - keydown event
    */
   onKeyDownListener(event) {
-    if (event.key === 'Tab') {
-      event.stopPropagation();
-    }
-
-    if (event.key === 'Backspace') {
+    if (event.key === 'Tab' || event.key === 'Backspace') {
       event.stopPropagation();
     }
   }


### PR DESCRIPTION
Scenario:

Step1: create 3 * 3 table
Step2: click on Row 3 Col1, don't do anything
Step3: click on Row 2 Col1, then click backspace.
Issue1: Without removing/clearing the Row2 Col1 content, cursor moves to Row2 Col3.

Fix: Prevented the cursor to move other cells instead of focusing the current cell.

Please let me know if you are having any concerns on this.

GitHub Issue ID: https://miniature-space-enigma-w4v5957jjjxcp4p.github.dev/