### PR TITLE
Fix bugs initializing stretched and pasted tables.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -248,6 +248,7 @@ export default class TableBlock {
     /** Update Tool's data */
     this.data = {
       withHeadings: firstRowHeading !== null,
+      stretched: false,
       content
     };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,6 +70,7 @@ export default class TableBlock {
     };
     this.table = null;
     this.block = block;
+    this.container = null;
   }
 
   /**
@@ -106,6 +107,7 @@ export default class TableBlock {
 
   /**
    * Hook called after the block is fully rendered and mounted
+   * Set this.block.stretched here as block is not initialized in render().
    *
    * @returns {void}
    */

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -105,6 +105,17 @@ export default class TableBlock {
   }
 
   /**
+   * Hook called after the block is fully rendered and mounted
+   *
+   * @returns {void}
+   */
+  rendered() {
+    if (this.block) {
+      this.block.stretched = !!this.data.stretched;
+    }
+  }
+
+  /**
    * Returns plugin settings
    *
    * @returns {Array}
@@ -119,7 +130,7 @@ export default class TableBlock {
         toggle: true,
         onActivate: () => {
           this.data.withHeadings = true;
-          this.table.setHeadingsSetting(this.data.withHeadings);
+          this._updateTunes();
         }
       }, {
         label: this.api.i18n.t('Without headings'),
@@ -129,7 +140,7 @@ export default class TableBlock {
         toggle: true,
         onActivate: () => {
           this.data.withHeadings = false;
-          this.table.setHeadingsSetting(this.data.withHeadings);
+          this._updateTunes();
         }
       }, {
         label: this.data.stretched ? this.api.i18n.t('Collapse') : this.api.i18n.t('Stretch'),
@@ -138,11 +149,26 @@ export default class TableBlock {
         toggle: true,
         onActivate: () => {
           this.data.stretched = !this.data.stretched;
-          this.block.stretched = this.data.stretched;
+          this._updateTunes();
         }
       }
     ];
   }
+
+  /**
+   * Handle updating UI for tunes
+   * 
+   * @returns {void}
+   */
+  _updateTunes() {
+    this.table.setHeadingsSetting(this.data.withHeadings);
+
+    if (this.block) {
+      this.block.stretched = !!this.data.stretched;
+      this.block.dispatchChange();
+    }
+  }
+
   /**
    * Extract table data from the view
    *

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,7 +70,6 @@ export default class TableBlock {
     };
     this.table = null;
     this.block = block;
-    this.container = null;
   }
 
   /**


### PR DESCRIPTION
This fixes the following:

* Table is not initialised correctly if stretch is selected.
* Cannot correctly stretch pasted table.

(using stretched-fix branch)